### PR TITLE
Fix: Prevent null from appearing in modal header when subject is empty

### DIFF
--- a/AttachmentGallery/index.ts
+++ b/AttachmentGallery/index.ts
@@ -416,7 +416,7 @@ export class AttachmentGallery implements ComponentFramework.StandardControl<IIn
                         id: result.entities[index].id,
                         mimeType: result.entities[index].mimetype,
                         noteText: result.entities[index].notetext,
-                        title: result.entities[index].subject,
+                        title: result.entities[index].subject || result.entities[index].filename,
                         filename: result.entities[index].filename,
                         documentBody: result.entities[index].documentbody
                     };


### PR DESCRIPTION
Problem:
When multiple attachments are uploaded, the modal header displayed values like 1/3null. This happened because the subject field from the annotation record (mapped to title) can be null, and it was rendered directly in the header.

Solution:

Updated GetAttachments so that if subject is empty, the filename is used as a fallback for the title.

Ensured the modal header always displays a valid string (subject or filename), avoiding null values in the UI.

Result:
Modal header now correctly shows 1/3 <filename> instead of 1/3null.